### PR TITLE
Replace slow nodes and keep list with fastest node in beginning

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@c4dt/cothority",
-  "version": "3.1.19",
+  "version": "3.1.20",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/spec/support/conondes.ts
+++ b/external/js/cothority/spec/support/conondes.ts
@@ -78,7 +78,7 @@ export async function stopConodes(): Promise<void> {
         await docker.getContainer(container.Id).remove();
     }
 
-    if (process.env.CI) {
+    if (process.env.CI && false) {
         // Write the logs for continuous integration as we don't have access
         // to the file
 

--- a/external/js/cothority/src/network/connection.ts
+++ b/external/js/cothority/src/network/connection.ts
@@ -1,5 +1,6 @@
 import { Message, util } from "protobufjs/light";
 import shuffle from "shuffle-array";
+import { sprintf } from "sprintf-js";
 import Log from "../log";
 import { Roster } from "./proto";
 import { BrowserWebSocketAdapter, WebSocketAdapter } from "./websocket-adapter";
@@ -44,8 +45,8 @@ export interface IConnection {
  * Single peer connection
  */
 export class WebSocketConnection implements IConnection {
-    private url: string;
-    private service: string;
+    private readonly url: string;
+    private readonly service: string;
     private timeout: number;
 
     /**
@@ -84,7 +85,7 @@ export class WebSocketConnection implements IConnection {
             const ws = factory(path);
             const bytes = Buffer.from(message.$type.encode(message).finish());
 
-            const timer = setTimeout(() => ws.close(1002, "timeout"), this.timeout);
+            const timer = setTimeout(() => ws.close(1000, "timeout"), this.timeout);
 
             ws.onOpen(() => ws.send(bytes));
 
@@ -114,7 +115,6 @@ export class WebSocketConnection implements IConnection {
                 // nativescript-websocket on iOS doesn't return error-code 1002 in case of error, but sets the 'reason'
                 // to non-null in case of error.
                 if (code !== 1000 || reason) {
-                    Log.error("Got close:", code, reason);
                     reject(new Error(reason));
                 }
             });
@@ -133,8 +133,11 @@ export class WebSocketConnection implements IConnection {
  * than one node in parallel and return the first success if 'parallel' i > 1.
  */
 export class RosterWSConnection {
-    private addresses: string[];
-    private connectionsActive: WebSocketConnection[];
+    static totalConnNbr = 0;
+    private readonly connNbr: number;
+    private msgNbr = 0;
+    private readonly addresses: string[];
+    private readonly connectionsActive: WebSocketConnection[];
     private connectionsPool: WebSocketConnection[];
 
     /**
@@ -142,9 +145,12 @@ export class RosterWSConnection {
      * @param service   The name of the service to reach
      * @param parallel how many nodes to contact in parallel
      */
-    constructor(r: Roster, private service: string, parallel: number = 2) {
+    constructor(r: Roster, private service: string, parallel: number = 3) {
         if (parallel < 1) {
             throw new Error("parallel must be >= 1");
+        }
+        if (parallel > r.list.length) {
+            parallel = r.list.length;
         }
         this.addresses = r.list.map((conode) => conode.getWebSocketAddress());
         shuffle(this.addresses);
@@ -152,6 +158,8 @@ export class RosterWSConnection {
         this.connectionsPool = this.addresses.map((addr) => new WebSocketConnection(addr, service));
         // And take the first 'parallel' connections
         this.connectionsActive = this.connectionsPool.splice(0, parallel);
+        this.connNbr = RosterWSConnection.totalConnNbr;
+        RosterWSConnection.totalConnNbr++;
         // Upon failure of a connection, it is pushed to the end of the connectionsPool, and a
         // new connection is taken from the beginning of the connectionsPool.
     }
@@ -168,6 +176,14 @@ export class RosterWSConnection {
     async send<T extends Message>(message: Message, reply: typeof Message): Promise<T> {
         const errors: string[] = [];
         let rotate = this.addresses.length - this.connectionsActive.length;
+        const msgNbr = this.msgNbr;
+        this.msgNbr++;
+        const start = Date.now();
+        let first = start;
+        let order = 0;
+
+        Log.lvl3(sprintf("%d/%d", this.connNbr, msgNbr), "sending", message.constructor.name, "with list:",
+            this.connectionsActive.map((conn) => conn.getURL()));
 
         // Get the first reply - need to take care not to return a reject too soon, else
         // all other promises will be ignored.
@@ -176,13 +192,29 @@ export class RosterWSConnection {
         return Promise.race(this.connectionsActive.map((_, i) => {
             return new Promise<T>(async (resolve, reject) => {
                 do {
+                    const conn = this.connectionsActive[i];
+                    const idStr = sprintf("%d/%d: %s - ", this.connNbr, msgNbr.toString(), conn.getURL());
                     try {
-                        const sub = await this.connectionsActive[i].send(message, reply);
+                        Log.lvl3(idStr, "sending");
+                        const sub = await conn.send(message, reply);
+                        const rcvd = Date.now();
+                        Log.lvl3(idStr, "received in position", order, "after:", rcvd - start);
+
                         // Signal to other connections that have an error that they don't need
                         // to retry.
-                        rotate = -1;
-                        resolve(sub as T);
+                        if (rotate >= 0) {
+                            first = rcvd;
+                            rotate = -1;
+                        }
+                        this.updateOrder(conn, order, (rcvd - start) / (first - start), idStr);
+                        order++;
+
+                        if (order === 1) {
+                            resolve(sub as T);
+                        }
                     } catch (e) {
+                        Log.lvl3(idStr, "has error", e);
+                        this.updateOrder(conn, 0, 0, idStr, true);
                         errors.push(e);
                         if (errors.length === this.addresses.length) {
                             // It's the last connection that also threw an error, so let's quit
@@ -191,8 +223,7 @@ export class RosterWSConnection {
                         rotate--;
                         if (rotate >= 0) {
                             // Take the oldest connection that hasn't been used yet
-                            this.connectionsPool.push(this.connectionsActive[i]);
-                            this.connectionsActive[i] = this.connectionsPool.shift();
+                            this.rotatePool(i);
                         }
                     }
                 } while (rotate >= 0);
@@ -217,6 +248,55 @@ export class RosterWSConnection {
         this.connectionsActive.forEach((conn) => {
             conn.setTimeout(value);
         });
+    }
+
+    /**
+     * Updates the order of the nodes, according to the incoming messages. Supposes that the messages
+     * are valid.
+     *
+     * @param conn the connection that received the message
+     * @param order the order the message has been received
+     * @param diff quotient of the time it took divided by the fastest time
+     * @param dbg a debug string to prepend to all outputs
+     * @param err if it is an error
+     */
+    private updateOrder(conn: WebSocketConnection, order: number, diff: number, dbg: string, err?: boolean) {
+        // Replace in the connectionsActive array according to the order the message was
+        // received
+        if (this.connectionsActive.length > 1) {
+            const pos = this.connectionsActive.indexOf(conn);
+            if (pos === -1) {
+                Log.lvl3(dbg, "is not in list anymore");
+            } else {
+                if (!err) {
+                    Log.lvl3(dbg, "switching", pos, "and", order);
+                    [this.connectionsActive[pos], this.connectionsActive[order]] =
+                        [this.connectionsActive[order], this.connectionsActive[pos]];
+                }
+                if (diff > 10 || err) {
+                    Log.lvl3(dbg, "rotating out: was really late or had error:", err);
+                    this.rotatePool(pos);
+                }
+                Log.lvl3(dbg, "list:", this.connectionsActive.map((c) => c.getURL()));
+            }
+        }
+    }
+
+    /**
+     * Puts the given element in the list of active nodes to the end of the pool, and replaces
+     * it with the first element of the pool, thus rotating an element of the active list with
+     * the pool.
+     *
+     * @param index
+     */
+    private rotatePool(index: number) {
+        if (this.connectionsPool.length === 0) {
+            return;
+        }
+        Log.lvl3("Replacing", index, this.connectionsActive[index].getURL(), "with",
+            this.connectionsPool[0].getURL());
+        this.connectionsPool.push(this.connectionsActive[index]);
+        this.connectionsActive[index] = this.connectionsPool.shift();
     }
 }
 


### PR DESCRIPTION
Keep the list of active nodes with the fastest node at the beginning. If a very slow node (>=10x slower than the fastest) receives a message, it will be replaced with another node from the list of waiting nodes.